### PR TITLE
Dynamically set BlockFrostChainContext base_url based on network in send_message

### DIFF
--- a/cardanomsg/transaction.py
+++ b/cardanomsg/transaction.py
@@ -29,7 +29,12 @@ def send_message(blockfrost_project_id, skey_path_name, recipient_address, amoun
     address = Address(pvk.hash(), network=network)
 
     # Create a BlockFrost chain context
-    context = BlockFrostChainContext(blockfrost_project_id, base_url=ApiUrls.preview.value)
+    network_urls = {
+        Network.MAINNET: ApiUrls.mainnet.value,
+        Network.TESTNET: ApiUrls.preview.value
+    }
+    api_base_url = network_urls[network]
+    context = BlockFrostChainContext(blockfrost_project_id, base_url=api_base_url)
 
     # Create a transaction builder
     builder = TransactionBuilder(context)


### PR DESCRIPTION
I noticed an issue where the `BlockFrostChainContext` in the method `send_message` was initialized with `ApiUrls.preview.value`, despite the parameter network being set to `MAINNET`.
This mismatch caused API requests to fail due to an incorrect network token.

The PR dynamically set the base_url based on the network parameter